### PR TITLE
Don't use symlink for steam (native) root

### DIFF
--- a/live.senkins.SeventhHeavenWrapper.yml
+++ b/live.senkins.SeventhHeavenWrapper.yml
@@ -24,8 +24,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   # Steam Flatpak
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
-  # Steam Deck - TODO we may also need xdg-data/Steam
-  - --filesystem=~/.local/share/Steam:ro
+  - --filesystem=xdg-data/Steam:ro
   - --env=WINEDLLPATH=/app/dlls/lib32:/app/dlls/lib
   - --env=WINEPREFIX=/var/data/wine
   - --env=WINEDLLOVERRIDES=winemenubuilder.exe=d,dinput=n

--- a/live.senkins.SeventhHeavenWrapper.yml
+++ b/live.senkins.SeventhHeavenWrapper.yml
@@ -25,7 +25,7 @@ finish-args:
   # Steam Flatpak
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
   # Steam Deck - TODO we may also need xdg-data/Steam
-  - --filesystem=~/.steam:ro
+  - --filesystem=~/.local/share/Steam:ro
   - --env=WINEDLLPATH=/app/dlls/lib32:/app/dlls/lib
   - --env=WINEPREFIX=/var/data/wine
   - --env=WINEDLLOVERRIDES=winemenubuilder.exe=d,dinput=n

--- a/tauri-app/src-tauri/src/steam_manager.rs
+++ b/tauri-app/src-tauri/src/steam_manager.rs
@@ -29,7 +29,7 @@ impl SteamManager {
         let home = home::home_dir().unwrap();
         [
             // Steam on Flatpak
-            home.join(".var/app/com.valvesoftware.Steam/.steam"),
+            home.join(".var/app/com.valvesoftware.Steam/.local/share/Steam"),
             // Steam Native
             home.join(".local/share/Steam")
         ].to_vec()

--- a/tauri-app/src-tauri/src/steam_manager.rs
+++ b/tauri-app/src-tauri/src/steam_manager.rs
@@ -17,7 +17,7 @@ impl SteamManager {
     pub fn detect_steam_home() -> Option<PathBuf>{
         for d in Self::known_steam_directories() {
             debug!("Testing {} for libraryfolders.vdf", d.display());
-            if d.join("steam/steamapps/libraryfolders.vdf").exists() {
+            if d.join("steamapps/libraryfolders.vdf").exists() {
                 return Some(d);
             }
         }
@@ -31,7 +31,7 @@ impl SteamManager {
             // Steam on Flatpak
             home.join(".var/app/com.valvesoftware.Steam/.steam"),
             // Steam Native
-            home.join(".steam")
+            home.join(".local/share/Steam")
         ].to_vec()
     }
 }


### PR DESCRIPTION
Since flatpak's permissions don't follow symlinks, we need to do it like this.